### PR TITLE
UCC: PrintNodeのNULLトークン参照を防止してテスト期待値を正しい値へ更新

### DIFF
--- a/ucc/ast.c
+++ b/ucc/ast.c
@@ -920,8 +920,13 @@ void PrintNode(FILE *out, struct Node *n, int indent, const char *key) {
   if (key) {
     fprintf(out, "%s", key);
   }
-  fprintf(out, "[%d %s token='%.*s' type=",
-         n->index, node_kind_name[n->kind], n->token->len, n->token->raw);
+  if (n->token) {
+    fprintf(out, "[%d %s token='%.*s' type=",
+           n->index, node_kind_name[n->kind], n->token->len, n->token->raw);
+  } else {
+    fprintf(out, "[%d %s token=(no-token) type=",
+           n->index, node_kind_name[n->kind]);
+  }
   if (n->type) {
     PrintType(out, n->type);
   } else {

--- a/ucc/ast.c
+++ b/ucc/ast.c
@@ -920,13 +920,15 @@ void PrintNode(FILE *out, struct Node *n, int indent, const char *key) {
   if (key) {
     fprintf(out, "%s", key);
   }
+  
+  fprintf(out, "[%d %s token=", n->index, node_kind_name[n->kind]);
   if (n->token) {
-    fprintf(out, "[%d %s token='%.*s' type=",
-           n->index, node_kind_name[n->kind], n->token->len, n->token->raw);
+    fprintf(out, "'%.*s'", n->token->len, n->token->raw);
   } else {
-    fprintf(out, "[%d %s token=(no-token) type=",
-           n->index, node_kind_name[n->kind]);
+    fprintf(out, "(no-token)");
   }
+  fprintf(out, " type=");
+
   if (n->type) {
     PrintType(out, n->type);
   } else {

--- a/ucc/tests/array.s
+++ b/ucc/tests/array.s
@@ -2,7 +2,7 @@ section .data
 
 section .text
 start:
-	call main
+	call buntan_main
 	st 6
 fin:
 	jmp fin

--- a/ucc/tests/const-expr.s
+++ b/ucc/tests/const-expr.s
@@ -2,7 +2,7 @@ section .data
 
 section .text
 start:
-	call main
+	call buntan_main
 	st 6
 fin:
 	jmp fin

--- a/ucc/tests/global-vars.s
+++ b/ucc/tests/global-vars.s
@@ -4,7 +4,7 @@ gv:
 
 section .text
 start:
-	call main
+	call buntan_main
 	st 6
 fin:
 	jmp fin

--- a/ucc/tests/if-stmt.s
+++ b/ucc/tests/if-stmt.s
@@ -2,7 +2,7 @@ section .data
 
 section .text
 start:
-	call main
+	call buntan_main
 	st 6
 fin:
 	jmp fin

--- a/ucc/tests/isr.s
+++ b/ucc/tests/isr.s
@@ -2,7 +2,7 @@ section .data
 
 section .text
 start:
-	call main
+	call buntan_main
 	st 6
 fin:
 	jmp fin

--- a/ucc/tests/large-push.s
+++ b/ucc/tests/large-push.s
@@ -2,7 +2,7 @@ section .data
 
 section .text
 start:
-	call main
+	call buntan_main
 	st 6
 fin:
 	jmp fin

--- a/ucc/tests/local-vars.s
+++ b/ucc/tests/local-vars.s
@@ -2,7 +2,7 @@ section .data
 
 section .text
 start:
-	call main
+	call buntan_main
 	st 6
 fin:
 	jmp fin

--- a/ucc/tests/return-inside-if.s
+++ b/ucc/tests/return-inside-if.s
@@ -2,7 +2,7 @@ section .data
 
 section .text
 start:
-	call main
+	call buntan_main
 	st 6
 fin:
 	jmp fin


### PR DESCRIPTION
- `ucc/ast.c`の`PrintNode`で`n->token`のNULLチェックを追加して、トークンが無い場合は`token=(no-token)`と出力するように安全化しました。これにより、`NewNode(kNodeReturn, NULL)`のような構文でクラッシュしないようになりました: https://github.com/buntan-pc/buntan-pc/commit/5fd0c0e79b0188009dda7b2d09195c4fc08e63e0

- uccのテストの期待値を最近の更新（main関数がbuntan_mainになった）に合わせて更新しました: https://github.com/buntan-pc/buntan-pc/commit/297e8b0880d085564b47712ef1a74e0a378334b4

uccのテストは通ります。